### PR TITLE
#58 - create specific namespace for vectors

### DIFF
--- a/vcl/include/utils/clipvect2.h
+++ b/vcl/include/utils/clipvect2.h
@@ -37,6 +37,7 @@ SOFTWARE.
 
 //===========================================================================
 namespace vcl {
+  namespace vect {
 
     //=======================================================================
     // Forward declaration and Specializations
@@ -166,10 +167,10 @@ namespace vcl {
             this->fill(this->clipped(value));
         }
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect2<TScalar, Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect2<TScalar, Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -257,10 +258,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect2c<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect2c<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -312,10 +313,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect2b<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect2b<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -368,10 +369,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect2s<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect2s<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -424,10 +425,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect2us<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect2us<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -480,10 +481,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect2i<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect2i<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -536,10 +537,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect2ui<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect2ui<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -592,10 +593,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect2f<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect2f<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -648,10 +649,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect2d<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect2d<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -674,4 +675,5 @@ namespace vcl {
         {}
     };
 
+  } // end of namespace vcl::vect::vect
 } // end of namespace vcl

--- a/vcl/include/utils/clipvect3.h
+++ b/vcl/include/utils/clipvect3.h
@@ -37,6 +37,7 @@ SOFTWARE.
 
 //===========================================================================
 namespace vcl {
+  namespace vect {
 
     //=======================================================================
     // Forward declaration and Specializations
@@ -166,10 +167,10 @@ namespace vcl {
             this->fill(this->clipped(value));
         }
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect3<TScalar, Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect3<TScalar, Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -270,10 +271,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect3c<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect3c<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -325,10 +326,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect3b<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect3b<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -381,10 +382,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect3s<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect3s<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -437,10 +438,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect3us<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect3us<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -493,10 +494,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect3i<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect3i<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -549,10 +550,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect3ui<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect3ui<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -605,10 +606,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect3f<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect3f<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -661,10 +662,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect3d<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect3d<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -687,4 +688,5 @@ namespace vcl {
         {}
     };
 
+  } // end of namespace vcl::vect::vect
 } // end of namespace vcl

--- a/vcl/include/utils/clipvect4.h
+++ b/vcl/include/utils/clipvect4.h
@@ -37,6 +37,7 @@ SOFTWARE.
 
 //===========================================================================
 namespace vcl {
+  namespace vect {
 
     //=======================================================================
     // Forward declaration and Specializations
@@ -164,10 +165,10 @@ namespace vcl {
             this->fill(this->clipped(value));
         }
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect4<TScalar, Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect4<TScalar, Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -281,10 +282,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect4c<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect4c<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -336,10 +337,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect4b<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect4b<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -392,10 +393,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect4s<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect4s<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -448,10 +449,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect4us<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect4us<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -504,10 +505,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect4i<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect4i<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -560,10 +561,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect4ui<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect4ui<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -616,10 +617,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect4f<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect4f<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -672,10 +673,10 @@ namespace vcl {
             : MyBaseType(other)
         {}
 
-        /** \brief Copy constructor (const vcl::Vector&).
+        /** \brief Copy constructor (const vcl::vect::Vector&).
         */
         template<typename T, size_t S>
-        inline ClipVect4d<Kmin, Kmax>(const vcl::Vector<T, S>& other)
+        inline ClipVect4d<Kmin, Kmax>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -698,4 +699,5 @@ namespace vcl {
         {}
     };
 
+  } // end of namespace vcl::vect::vect
 } // end of namespace vcl

--- a/vcl/include/utils/vect2.h
+++ b/vcl/include/utils/vect2.h
@@ -36,7 +36,7 @@ SOFTWARE.
 
 //===========================================================================
 namespace vcl {
-
+  namespace vect {
     //-----------------------------------------------------------------------
     // Forward declaration and Specializations
     template<typename TScalar> class Vect2;
@@ -93,7 +93,7 @@ namespace vcl {
         /** \brief Copy constructor (const&).
         */
         template<typename T, size_t S>
-        inline Vect2<TScalar>(const vcl::Vector<T, S>& other)
+        inline Vect2<TScalar>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -143,4 +143,5 @@ namespace vcl {
         }
     };
 
+  } // end of namespace vcl::vect::vect
 } // end of namespace vcl

--- a/vcl/include/utils/vect3.h
+++ b/vcl/include/utils/vect3.h
@@ -36,7 +36,7 @@ SOFTWARE.
 
 //===========================================================================
 namespace vcl {
-
+  namespace vect {
     //-----------------------------------------------------------------------
     // Forward declaration and Specializations
     template<typename TScalar> class Vect3;
@@ -93,7 +93,7 @@ namespace vcl {
         /** \brief Copy constructor (const&).
         */
         template<typename T, size_t S>
-        inline Vect3<TScalar>(const vcl::Vector<T, S>& other)
+        inline Vect3<TScalar>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -156,4 +156,5 @@ namespace vcl {
         }
     };
 
+  } // end of namespace vcl::vect::vect
 } // end of namespace vcl

--- a/vcl/include/utils/vect4.h
+++ b/vcl/include/utils/vect4.h
@@ -36,6 +36,7 @@ SOFTWARE.
 
 //===========================================================================
 namespace vcl {
+  namespace vect {
 
     //-----------------------------------------------------------------------
     // Forward declaration and Specializations
@@ -93,7 +94,7 @@ namespace vcl {
         /** \brief Copy constructor (const&).
         */
         template<typename T, size_t S>
-        inline Vect4<TScalar>(const vcl::Vector<T, S>& other)
+        inline Vect4<TScalar>(const vcl::vect::Vector<T, S>& other)
             : MyBaseType(other)
         {}
 
@@ -169,4 +170,5 @@ namespace vcl {
         }
     };
 
+  } // end of namespace vcl::vect::vect
 } // end of namespace vcl

--- a/vcl/include/utils/vector.h
+++ b/vcl/include/utils/vector.h
@@ -34,6 +34,7 @@ SOFTWARE.
 
 //===========================================================================
 namespace vcl {
+  namespace vect {
 
     //-----------------------------------------------------------------------
     /** \brief the generic class for vectors.
@@ -135,7 +136,7 @@ namespace vcl {
         /** \brief Copy constructor (const&).
         */
         template<typename T, size_t S>
-        inline Vector<TScalar, Ksize>(const vcl::Vector<T,S>& other)
+        inline Vector<TScalar, Ksize>(const vcl::vect::Vector<T,S>& other)
             : MyBaseType()
         {
             zero();
@@ -169,9 +170,9 @@ namespace vcl {
 
 
         //---   copy()   ----------------------------------------------------
-        /** \brief Copies a const vcl::Vector. */
+        /** \brief Copies a const vcl::vect::Vector. */
         template<typename T, size_t S>
-        inline void copy(const vcl::Vector<T,S>& other)
+        inline void copy(const vcl::vect::Vector<T,S>& other)
         {
             auto ot = other.cbegin();
             for (auto it = this->begin(); it != this->end() && ot !=  other.cend(); )
@@ -295,9 +296,9 @@ namespace vcl {
             return *this;
         }
 
-        /** \brief assign operator (const vcl::Vector). */
+        /** \brief assign operator (const vcl::vect::Vector). */
         template<typename T, size_t S>
-        inline MyType& operator= (const vcl::Vector<T,S>& other)
+        inline MyType& operator= (const vcl::vect::Vector<T,S>& other)
         {
             copy(other);
             return *this;
@@ -322,7 +323,7 @@ namespace vcl {
         //---   operator +=   -----------------------------------------------
         /** \brief += operator (const reference) */
         template<typename T, size_t S>
-        inline MyType& operator+= (const vcl::Vector<T,S>& rhs)
+        inline MyType& operator+= (const vcl::vect::Vector<T,S>& rhs)
         {
             add(rhs);
             return *this;
@@ -415,7 +416,7 @@ namespace vcl {
             return *this;
         }
 
-        /** \brief += operator (std::array, vcl::Vector) */
+        /** \brief += operator (std::array, vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline std::array<T, S>& operator+= (std::array<T, S> lhs, const MyType& rhs)
         {
@@ -431,7 +432,7 @@ namespace vcl {
             return *this;
         }
 
-        /** \brief += operator (std::vector, vcl::Vector) */
+        /** \brief += operator (std::vector, vcl::vect::Vector) */
         template<typename T>
         friend inline std::vector<T>& operator+= (std::vector<T> lhs, const MyType& rhs)
         {
@@ -444,7 +445,7 @@ namespace vcl {
         * Note: optimized for chained v1+v2+v3
         */
         template<typename T, size_t S>
-        friend inline MyType operator+ (MyType lhs, const vcl::Vector<T, S>& rhs)
+        friend inline MyType operator+ (MyType lhs, const vcl::vect::Vector<T, S>& rhs)
         {
             return lhs += rhs;
         }
@@ -515,7 +516,7 @@ namespace vcl {
             return lhs += value;
         }
 
-        /** \brief + operator (const TScalar, vcl::Vector) */
+        /** \brief + operator (const TScalar, vcl::vect::Vector) */
         friend inline MyType operator+ (const char value, MyType rhs)
         {
             return rhs += value;
@@ -588,7 +589,7 @@ namespace vcl {
             return lhs += rhs;
         }
 
-        /** \brief + operator (const std::array, vcl::Vector) */
+        /** \brief + operator (const std::array, vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline std::array<T, S> operator+ (std::array<T, S> lhs, MyType rhs)
         {
@@ -602,7 +603,7 @@ namespace vcl {
             return lhs += rhs;
         }
 
-        /** \brief + operator (const std::vector, vcl::Vector) */
+        /** \brief + operator (const std::vector, vcl::vect::Vector) */
         template<typename T>
         friend inline std::vector<T> operator+ (std::vector<T> lhs, MyType rhs)
         {
@@ -619,7 +620,7 @@ namespace vcl {
         //---   operators -=   ----------------------------------------------
         /** \brief -= operator (const reference) */
         template<typename T, size_t S>
-        inline MyType& operator-= (const vcl::Vector<T,S>& rhs)
+        inline MyType& operator-= (const vcl::vect::Vector<T,S>& rhs)
         {
             sub(rhs);
             return *this;
@@ -712,7 +713,7 @@ namespace vcl {
             return *this;
         }
 
-        /** \brief -= operator (std::array, vcl::Vector) */
+        /** \brief -= operator (std::array, vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline std::array<T, S>& operator-= (std::array<T, S> lhs, const MyType& rhs)
         {
@@ -728,7 +729,7 @@ namespace vcl {
             return *this;
         }
 
-        /** \brief -= operator (std::vector, vcl::Vector) */
+        /** \brief -= operator (std::vector, vcl::vect::Vector) */
         template<typename T>
         friend inline std::vector<T>& operator-= (std::vector<T> lhs, const MyType& rhs)
         {
@@ -741,7 +742,7 @@ namespace vcl {
         * Note: optimized for chained v1-v2-v3
         */
         template<typename T, size_t S>
-        friend inline MyType operator- (MyType lhs, const vcl::Vector<T, S>& rhs)
+        friend inline MyType operator- (MyType lhs, const vcl::vect::Vector<T, S>& rhs)
         {
             return lhs -= rhs;
         }
@@ -812,7 +813,7 @@ namespace vcl {
             return lhs -= value;
         }
 
-        /** \brief - operator (const TScalar, vcl::Vector) */
+        /** \brief - operator (const TScalar, vcl::vect::Vector) */
         friend inline MyType operator- (const char value, MyType rhs)
         {
             return MyType(value) -= rhs;
@@ -885,7 +886,7 @@ namespace vcl {
             return lhs -= rhs;
         }
 
-        /** \brief - operator (const std::array, vcl::Vector) */
+        /** \brief - operator (const std::array, vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline std::array<T, S> operator- (std::array<T, S> lhs, MyType rhs)
         {
@@ -899,7 +900,7 @@ namespace vcl {
             return lhs -= rhs;
         }
 
-        /** \brief - operator (const std::vector, vcl::Vector) */
+        /** \brief - operator (const std::vector, vcl::vect::Vector) */
         template<typename T>
         friend inline std::vector<T> operator- (const std::vector<T> lhs, MyType rhs)
         {
@@ -915,7 +916,7 @@ namespace vcl {
         //---   operators *= and  *   ---------------------------------------
         /** \brief *= operator (const reference) */
         template<typename T, size_t S>
-        inline MyType& operator*= (const vcl::Vector<T,S>& rhs)
+        inline MyType& operator*= (const vcl::vect::Vector<T,S>& rhs)
         {
             mul(rhs);
             return *this;
@@ -1008,7 +1009,7 @@ namespace vcl {
             return *this;
         }
 
-        /** \brief *= operator (std::array, vcl::Vector) */
+        /** \brief *= operator (std::array, vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline std::array<T, S>& operator*= (std::array<T, S>& lhs, const MyType& rhs)
         {
@@ -1024,7 +1025,7 @@ namespace vcl {
             return *this;
         }
 
-        /** \brief *= operator (std::vector, vcl::Vector) */
+        /** \brief *= operator (std::vector, vcl::vect::Vector) */
         template<typename T>
         friend inline std::vector<T>& operator*= (std::vector<T>& lhs, const MyType& rhs)
         {
@@ -1037,12 +1038,12 @@ namespace vcl {
         * Note: optimized for chained v1*v2*v3
         */
         template<typename T, size_t S>
-        friend inline MyType operator* (MyType lhs, const vcl::Vector<T, S>& rhs)
+        friend inline MyType operator* (MyType lhs, const vcl::vect::Vector<T, S>& rhs)
         {
             return lhs *= rhs;
         }
 
-        /** \brief * operator (vcl::Vector, const TScalar) */
+        /** \brief * operator (vcl::vect::Vector, const TScalar) */
         friend inline MyType operator* (MyType lhs, const char value)
         {
             return lhs *= value;
@@ -1108,7 +1109,7 @@ namespace vcl {
             return lhs *= value;
         }
 
-        /** \brief * operator (const TScalar, vcl::Vector) */
+        /** \brief * operator (const TScalar, vcl::vect::Vector) */
         friend inline MyType operator* (const char value, MyType rhs)
         {
             return rhs *= value;
@@ -1181,7 +1182,7 @@ namespace vcl {
             return lhs *= rhs;
         }
 
-        /** \brief * operator (const std::array, vcl::Vector) */
+        /** \brief * operator (const std::array, vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline std::array<T, S> operator* (std::array<T, S> lhs, MyType rhs)
         {
@@ -1195,7 +1196,7 @@ namespace vcl {
             return lhs *= rhs;
         }
 
-        /** \brief * operator (const std::vector, vcl::Vector) */
+        /** \brief * operator (const std::vector, vcl::vect::Vector) */
         template<typename T>
         friend inline std::vector<T> operator* (std::vector<T> lhs, MyType rhs)
         {
@@ -1206,7 +1207,7 @@ namespace vcl {
         //---   operators /= and  /   ---------------------------------------
         /** \brief /= operator (const reference) */
         template<typename T, size_t S>
-        inline MyType& operator/= (const vcl::Vector<T, S>& rhs)
+        inline MyType& operator/= (const vcl::vect::Vector<T, S>& rhs)
         {
             div(rhs);
             return *this;
@@ -1299,7 +1300,7 @@ namespace vcl {
             return *this;
         }
 
-        /** \brief /= operator (std::array, vcl::Vector) */
+        /** \brief /= operator (std::array, vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline std::array<T, S>& operator/= (std::array<T, S> lhs, const MyType& rhs)
         {
@@ -1315,7 +1316,7 @@ namespace vcl {
             return *this;
         }
 
-        /** \brief /= operator (std::vector, vcl::Vector) */
+        /** \brief /= operator (std::vector, vcl::vect::Vector) */
         template<typename T>
         friend inline std::vector<T>& operator/= (std::vector<T> lhs, const MyType& rhs)
         {
@@ -1329,12 +1330,12 @@ namespace vcl {
         * Note: optimized for chained v1/v2/v3
         */
         template<typename T, size_t S>
-        friend inline MyType operator/ (MyType lhs, const vcl::Vector<T, S>& rhs)
+        friend inline MyType operator/ (MyType lhs, const vcl::vect::Vector<T, S>& rhs)
         {
             return lhs /= rhs;
         }
 
-        /** \brief / operator (vcl::Vector, const TScalar) */
+        /** \brief / operator (vcl::vect::Vector, const TScalar) */
         friend inline MyType operator/ (MyType lhs, const char value)
         {
             return lhs /= value;
@@ -1400,7 +1401,7 @@ namespace vcl {
             return lhs /= value;
         }
 
-        /** \brief / operator (const T Scalar, vcl::Vector) */
+        /** \brief / operator (const T Scalar, vcl::vect::Vector) */
         friend inline MyType operator/ (const char value, MyType& rhs)
         {
             return MyType(value) /= rhs;
@@ -1473,7 +1474,7 @@ namespace vcl {
             return lhs /= rhs;
         }
 
-        /** \brief / operator (const std::array, vcl::Vector) */
+        /** \brief / operator (const std::array, vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline std::array<T, S> operator/ (std::array<T, S> lhs, MyType rhs)
         {
@@ -1487,7 +1488,7 @@ namespace vcl {
             return lhs /= rhs;
         }
 
-        /** \brief / operator (const std::vector, vcl::Vector) */
+        /** \brief / operator (const std::vector, vcl::vect::Vector) */
         template<typename T>
         friend inline std::vector<T> operator/ (const std::vector<T> lhs, MyType rhs)
         {
@@ -1530,7 +1531,7 @@ namespace vcl {
         //---   add()   -----------------------------------------------------
         /** \brief inplace add operation (const reference) */
         template<typename T, size_t S>
-        inline void add(const vcl::Vector<T, S>& rhs)
+        inline void add(const vcl::vect::Vector<T, S>& rhs)
         {
             auto rit = rhs.cbegin();
             for (auto it = this->begin(); it != this->end() && rit != rhs.cend(); )
@@ -1625,7 +1626,7 @@ namespace vcl {
                 *it = clipped(*it + *rit++);
         }
 
-        /** \brief inplace add operation (std::array, const vcl::Vector) */
+        /** \brief inplace add operation (std::array, const vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline void add(std::array<T, S>& lhs, const MyType& rhs)
         {
@@ -1643,7 +1644,7 @@ namespace vcl {
                 *it = clipped(*it + *rit++);
         }
 
-        /** \brief inplace add operation (std::vector, const vcl::Vector) */
+        /** \brief inplace add operation (std::vector, const vcl::vect::Vector) */
         template<typename T>
         friend inline void add(std::vector<T>& lhs, const MyType& rhs)
         {
@@ -1656,7 +1657,7 @@ namespace vcl {
         //---   sub()   -----------------------------------------------------
         /** \brief inplace sub operation (const reference) */
         template<typename T, size_t S>
-        inline void sub(const vcl::Vector<T, S>& rhs)
+        inline void sub(const vcl::vect::Vector<T, S>& rhs)
         {
             auto rit = rhs.cbegin();
             for (auto it = this->begin(); it != this->end() && rit != rhs.cend(); )
@@ -1751,7 +1752,7 @@ namespace vcl {
                 *it = clipped(*it - *rit++);
         }
 
-        /** \brief inplace sub operation (std::array, const vcl::Vector) */
+        /** \brief inplace sub operation (std::array, const vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline void sub(std::array<T, S>& lhs, const MyType& rhs)
         {
@@ -1769,7 +1770,7 @@ namespace vcl {
                 *it = clipped(*it - *rit++);
         }
 
-        /** \brief inplace sub operation (std::vector, const vcl::Vector) */
+        /** \brief inplace sub operation (std::vector, const vcl::vect::Vector) */
         template<typename T>
         friend inline void sub(std::vector<T>& lhs, const MyType& rhs)
         {
@@ -1782,7 +1783,7 @@ namespace vcl {
         //---   mul()   -----------------------------------------------------
         /** \brief inplace mul operation (const reference) */
         template<typename T, size_t S>
-        inline void mul(const vcl::Vector<T, S>& rhs)
+        inline void mul(const vcl::vect::Vector<T, S>& rhs)
         {
             auto rit = rhs.cbegin();
             for (auto it = this->begin(); it != this->end() && rit != rhs.cend(); )
@@ -1877,7 +1878,7 @@ namespace vcl {
                 *it = clipped(*it * *rit++);
         }
 
-        /** \brief inplace mul operation (std::array, const vcl::Vector) */
+        /** \brief inplace mul operation (std::array, const vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline void mul(std::array<T, S>& lhs, const MyType& rhs)
         {
@@ -1895,7 +1896,7 @@ namespace vcl {
                 *it = clipped(*it * *rit++);
         }
 
-        /** \brief inplace mul operation (std::vector, const vcl::Vector) */
+        /** \brief inplace mul operation (std::vector, const vcl::vect::Vector) */
         template<typename T>
         friend inline void mul(std::vector<T>& lhs, const MyType& rhs)
         {
@@ -1908,7 +1909,7 @@ namespace vcl {
         //---   div()   -----------------------------------------------------
         /** \brief inplace div operation (const reference) */
         template<typename T, size_t S>
-        inline void div(const vcl::Vector<T, S>& rhs)
+        inline void div(const vcl::vect::Vector<T, S>& rhs)
         {
             auto rit = rhs.cbegin();
             for (auto it = this->begin(); it != this->end() && rit != rhs.cend(); it++, rit++)
@@ -2018,7 +2019,7 @@ namespace vcl {
                     *it = clipped(*it / *rit);
         }
 
-        /** \brief inplace div operation (std::array, const vcl::Vector) */
+        /** \brief inplace div operation (std::array, const vcl::vect::Vector) */
         template<typename T, size_t S>
         friend inline void div(std::array<T, S>& lhs, const MyType& rhs)
         {
@@ -2038,7 +2039,7 @@ namespace vcl {
                     *it = clipped(*it / *rit);
         }
 
-        /** \brief inplace div operation (std::vector, const vcl::Vector) */
+        /** \brief inplace div operation (std::vector, const vcl::vect::Vector) */
         template<typename T>
         friend inline void div(std::vector<T>& lhs, const MyType& rhs)
         {
@@ -2050,4 +2051,5 @@ namespace vcl {
 
     }; // end of class Vector<typename TScalar, const size_t Ksize>
 
+  } // end of namespace vcl::vect::vect
 } // end of namespace vcl


### PR DESCRIPTION
Completed, tested.
New namespace is now **`vcl::vect`**.